### PR TITLE
Fixed natToMod and implemented group-action-based modular arithmetic.

### DIFF
--- a/src/Data/Mod.idr
+++ b/src/Data/Mod.idr
@@ -3,6 +3,7 @@ module Data.Mod
 %default total
 
 ||| Modular arithmetic
+abstract
 data Mod : (n : Nat) -> Type where
   mZ : Mod (S k)
   mS : Mod k -> Mod (S k)


### PR DESCRIPTION
natToMod was not defined correctly in the previous commit. It would
produce the wrong result in cases where the argument wrapped the modulus
like `the (Mod 3) (natToMod 4)`. Now it works.

Implemented rotate which is equivalent to (+ (mS mZ)). Then defined
`modplus` in terms of successive rotations, recursive in the first argument,
to mimic Nat's first-argument recursion.
